### PR TITLE
FrameProcessor: Fix returned values of cv2.findContours

### DIFF
--- a/ImageProcessing/FrameProcessor.py
+++ b/ImageProcessing/FrameProcessor.py
@@ -83,7 +83,7 @@ class FrameProcessor:
         debug_images.append(('Inversed', inverse))
 
         # Find the lcd digit contours
-        _, contours, _ = cv2.findContours(inverse, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE)  # get contours
+        contours, _ = cv2.findContours(inverse, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE)  # get contours
 
         # Assuming we find some, we'll sort them in order left -> right
         if len(contours) > 0:


### PR DESCRIPTION
Currently the method `findContours` returns only 2 parameters, rather than 3.

Without the patch, the `playground` script crashes.

@kazmiekr , are you interested in further such patches?