### PR TITLE
Fix oder of image loading - before UI setup

### DIFF
--- a/ImageProcessing/FrameProcessor.py
+++ b/ImageProcessing/FrameProcessor.py
@@ -22,6 +22,9 @@ class FrameProcessor:
         self.knn = self.train_knn(self.version)
 
     def set_image(self, file_name):
+        if not os.path.isfile(file_name):
+            raise IOError("File doesn't exist:", file_name)
+
         self.file_name = file_name
         self.img = cv2.imread(file_name)
         self.original, self.width = self.resize_to_height(self.height)

--- a/playground.py
+++ b/playground.py
@@ -24,8 +24,8 @@ def main():
     img_file = file_name
     if len(sys.argv) == 2:
         img_file = sys.argv[1]
-    setup_ui()
     frameProcessor.set_image(img_file)
+    setup_ui()
     process_image()
     cv2.waitKey()
 


### PR DESCRIPTION
Fixes IO problems when the UI wants to display the images in a second thread, but the 1st thread still hasn't loaded them yet.

On my box there were exceptions being thrown from the UI thread.