### PR TITLE
Fix tile display: current stack y pos reset

### DIFF
--- a/DisplayUtils/TileDisplay.py
+++ b/DisplayUtils/TileDisplay.py
@@ -28,5 +28,5 @@ def show_img(name, img):
 def reset_tiles():
     global current_stack_x, current_stack_y, current_stack_width
     current_stack_x = 0
-    current_stack_y = current_stack_y
+    current_stack_y = 0
     current_stack_width = 0


### PR DESCRIPTION
At each change of the knobs the windows' position was being reorganized. Now it's fixed to 0.